### PR TITLE
Fix CID normalization to use AT Protocol link format

### DIFF
--- a/src/Services/FirehoseConsumer.php
+++ b/src/Services/FirehoseConsumer.php
@@ -224,7 +224,7 @@ class FirehoseConsumer
                 // Decode the CBOR block to get the record data
                 $decoded = rescue(fn () => CBOR::decode($blocks[$cidStr]));
                 if (is_array($decoded)) {
-                    $record = $decoded;
+                    $record = $this->normalizeCids($decoded);
                 }
             }
 
@@ -267,6 +267,23 @@ class FirehoseConsumer
             kind: 'commit',
             commit: $commitEvent
         );
+    }
+
+    /**
+     * Normalize CID objects to AT Protocol link format.
+     */
+    protected function normalizeCids(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if ($value instanceof CID) {
+                // Convert CID to AT Protocol link format
+                $data[$key] = ['$link' => $value->toString()];
+            } elseif (is_array($value)) {
+                $data[$key] = $this->normalizeCids($value);
+            }
+        }
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
Fixes CID object serialization in Firehose records to match AT Protocol specifications.

### What Changed
- CID objects are now converted to `{"$link": "bafyrei..."}` format instead of plain strings
- Ensures blob references and other CID links follow AT Protocol spec

### Bug Fix
Previously, CID objects in records (like blob refs) were being converted to plain strings, which doesn't match the AT Protocol link format specification. This caused issues when consuming records with blob references.

**Before:**
```json
"ref": "bafkreif7wault54..."
```

**After:**
```json
"ref": {
    "$link": "bafkreif7wault54..."
}
```