### PR TITLE
Hude namespace refactor

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,8 +1,6 @@
 name: Code Style
 
 on:
-  push:
-    branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.phpunit.cache
 .phpunit.result.cache
 .php-cs-fixer.cache
 composer.lock

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Think of it as Laravel's event listeners, but for the decentralized social web.
 ## Quick Example
 
 ```php
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class NewPostSignal extends Signal
 {

--- a/composer.json
+++ b/composer.json
@@ -19,21 +19,21 @@
     },
     "autoload": {
         "psr-4": {
-            "SocialDept\\Signals\\": "src/"
+            "SocialDept\\AtpSignals\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "SocialDept\\Signals\\Tests\\": "tests/"
+            "SocialDept\\AtpSignals\\Tests\\": "tests/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "SocialDept\\Signals\\SignalServiceProvider"
+                "SocialDept\\AtpSignals\\SignalServiceProvider"
             ],
             "aliases": {
-                "Signal": "SocialDept\\Signals\\Facades\\Signal"
+                "Signal": "SocialDept\\AtpSignals\\Facades\\Signal"
             }
         }
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -539,7 +539,7 @@ SIGNAL_QUEUE=signal
 Change configuration at runtime:
 
 ```php
-use SocialDept\Signals\Facades\Signal;
+use SocialDept\AtpSignals\Facades\Signal;
 
 // Override mode
 config(['signal.mode' => 'firehose']);
@@ -578,7 +578,7 @@ $mode = config('signal.mode'); // 'jetstream' or 'firehose'
 Or via Facade:
 
 ```php
-use SocialDept\Signals\Facades\Signal;
+use SocialDept\AtpSignals\Facades\Signal;
 
 $mode = Signal::getMode();
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,9 +12,9 @@ Track engagement metrics across Bluesky.
 namespace App\Signals;
 
 use App\Models\EngagementMetric;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 use Illuminate\Support\Facades\DB;
 
 class EngagementTrackerSignal extends Signal
@@ -78,9 +78,9 @@ namespace App\Signals;
 
 use App\Models\FlaggedPost;
 use App\Services\ModerationService;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class ModerationSignal extends Signal
 {
@@ -158,9 +158,9 @@ namespace App\Signals;
 
 use App\Models\Activity;
 use App\Models\User;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class ActivityFeedSignal extends Signal
 {
@@ -243,9 +243,9 @@ namespace App\Signals;
 
 use App\Models\User;
 use App\Notifications\MentionedInPost;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class MentionNotificationSignal extends Signal
 {
@@ -314,9 +314,9 @@ namespace App\Signals;
 use App\Models\Follow;
 use App\Models\User;
 use App\Notifications\NewFollower;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class FollowTrackerSignal extends Signal
 {
@@ -393,9 +393,9 @@ namespace App\Signals;
 
 use App\Models\Post;
 use Laravel\Scout\Searchable;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class SearchIndexerSignal extends Signal
 {
@@ -477,9 +477,9 @@ namespace App\Signals;
 
 use App\Models\TrendingTopic;
 use Illuminate\Support\Facades\Cache;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class TrendDetectionSignal extends Signal
 {
@@ -553,9 +553,9 @@ Index custom collections for your AppView.
 namespace App\Signals;
 
 use App\Models\Publication;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class PublicationIndexerSignal extends Signal
 {
@@ -633,8 +633,8 @@ namespace App\Signals;
 
 use App\Services\ExternalAPIService;
 use Illuminate\Support\Facades\RateLimiter;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class APIIntegrationSignal extends Signal
 {
@@ -695,9 +695,9 @@ Track engagement across multiple collection types.
 namespace App\Signals;
 
 use App\Models\UserMetrics;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class UserMetricsSignal extends Signal
 {

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -30,7 +30,7 @@ The most basic filter - required for all Signals.
 ### Available Event Types
 
 ```php
-use SocialDept\Signals\Enums\SignalEventType;
+use SocialDept\AtpSignals\Enums\SignalEventType;
 
 public function eventTypes(): array
 {
@@ -210,7 +210,7 @@ Filter by operation type (only applies to commit events).
 ### Available Operations
 
 ```php
-use SocialDept\Signals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
 
 public function operations(): ?array
 {

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -318,7 +318,7 @@ SIGNAL_MODE=jetstream
 ### Option 2: Runtime Configuration
 
 ```php
-use SocialDept\Signals\Facades\Signal;
+use SocialDept\AtpSignals\Facades\Signal;
 
 // Set mode dynamically
 config(['signal.mode' => 'jetstream']);
@@ -467,7 +467,7 @@ $mode = config('signal.mode'); // 'jetstream' or 'firehose'
 Or via Facade:
 
 ```php
-use SocialDept\Signals\Facades\Signal;
+use SocialDept\AtpSignals\Facades\Signal;
 
 $mode = Signal::getMode();
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,8 +33,8 @@ Open the generated file and update it:
 
 namespace App\Signals;
 
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 use Illuminate\Support\Facades\Log;
 
 class NewPostSignal extends Signal
@@ -154,7 +154,7 @@ Now that you've built your first Signal, let's make it more useful.
 Track specific operations only:
 
 ```php
-use SocialDept\Signals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
 
 public function operations(): ?array
 {
@@ -242,9 +242,9 @@ Let's build a simple engagement tracker:
 namespace App\Signals;
 
 use App\Models\EngagementMetric;
-use SocialDept\Signals\Enums\SignalCommitOperation;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class EngagementTrackerSignal extends Signal
 {

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -21,8 +21,8 @@ Every Signal extends the base `Signal` class:
 
 namespace App\Signals;
 
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class MySignal extends Signal
 {
@@ -83,8 +83,8 @@ You can also create Signals manually in `app/Signals/`:
 
 namespace App\Signals;
 
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class ManualSignal extends Signal
 {
@@ -111,7 +111,7 @@ Signals can listen for three types of AT Protocol events:
 Repository commits represent changes to user data:
 
 ```php
-use SocialDept\Signals\Enums\SignalEventType;
+use SocialDept\AtpSignals\Enums\SignalEventType;
 
 public function eventTypes(): array
 {
@@ -339,7 +339,7 @@ public function handle(SignalEvent $event): void
 ### Operation Checking (Commit Events)
 
 ```php
-use SocialDept\Signals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
 
 public function handle(SignalEvent $event): void
 {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,8 +64,8 @@ Test your Signals in isolation.
 namespace Tests\Unit\Signals;
 
 use App\Signals\NewPostSignal;
-use SocialDept\Signals\Events\CommitEvent;
-use SocialDept\Signals\Events\SignalEvent;
+use SocialDept\AtpSignals\Events\CommitEvent;
+use SocialDept\AtpSignals\Events\SignalEvent;
 use Tests\TestCase;
 
 class NewPostSignalTest extends TestCase
@@ -186,8 +186,8 @@ namespace Tests\Feature\Signals;
 use App\Models\Post;
 use App\Signals\StorePostSignal;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use SocialDept\Signals\Events\CommitEvent;
-use SocialDept\Signals\Events\SignalEvent;
+use SocialDept\AtpSignals\Events\CommitEvent;
+use SocialDept\AtpSignals\Events\SignalEvent;
 use Tests\TestCase;
 
 class StorePostSignalTest extends TestCase

--- a/src/Binary/Reader.php
+++ b/src/Binary/Reader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\Binary;
+namespace SocialDept\AtpSignals\Binary;
 
 use RuntimeException;
 

--- a/src/Binary/Varint.php
+++ b/src/Binary/Varint.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\Binary;
+namespace SocialDept\AtpSignals\Binary;
 
 use RuntimeException;
 

--- a/src/CAR/BlockReader.php
+++ b/src/CAR/BlockReader.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\CAR;
+namespace SocialDept\AtpSignals\CAR;
 
 use Generator;
-use SocialDept\Signals\Binary\Reader;
-use SocialDept\Signals\Core\CID;
+use SocialDept\AtpSignals\Binary\Reader;
+use SocialDept\AtpSignals\Core\CID;
 
 /**
  * CAR (Content Addressable aRchive) block reader.

--- a/src/CAR/RecordExtractor.php
+++ b/src/CAR/RecordExtractor.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\CAR;
+namespace SocialDept\AtpSignals\CAR;
 
 use Generator;
-use SocialDept\Signals\Core\CBOR;
-use SocialDept\Signals\Core\CID;
+use SocialDept\AtpSignals\Core\CBOR;
+use SocialDept\AtpSignals\Core\CID;
 
 /**
  * Extract records from AT Protocol MST (Merkle Search Tree) blocks.

--- a/src/CBOR/Decoder.php
+++ b/src/CBOR/Decoder.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\CBOR;
+namespace SocialDept\AtpSignals\CBOR;
 
 use RuntimeException;
-use SocialDept\Signals\Binary\Reader;
-use SocialDept\Signals\Core\CID;
+use SocialDept\AtpSignals\Binary\Reader;
+use SocialDept\AtpSignals\Core\CID;
 
 /**
  * CBOR (Concise Binary Object Representation) decoder.

--- a/src/Commands/ConsumeCommand.php
+++ b/src/Commands/ConsumeCommand.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace SocialDept\Signals\Commands;
+namespace SocialDept\AtpSignals\Commands;
 
 use BackedEnum;
 use Exception;
 use Illuminate\Console\Command;
-use SocialDept\Signals\Services\FirehoseConsumer;
-use SocialDept\Signals\Services\JetstreamConsumer;
-use SocialDept\Signals\Services\SignalRegistry;
+use SocialDept\AtpSignals\Services\FirehoseConsumer;
+use SocialDept\AtpSignals\Services\JetstreamConsumer;
+use SocialDept\AtpSignals\Services\SignalRegistry;
 
 class ConsumeCommand extends Command
 {

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Commands;
+namespace SocialDept\AtpSignals\Commands;
 
 use Illuminate\Console\Command;
 

--- a/src/Commands/ListSignalsCommand.php
+++ b/src/Commands/ListSignalsCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SocialDept\Signals\Commands;
+namespace SocialDept\AtpSignals\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use SocialDept\Signals\Services\SignalRegistry;
+use SocialDept\AtpSignals\Services\SignalRegistry;
 
 class ListSignalsCommand extends Command
 {

--- a/src/Commands/MakeSignalCommand.php
+++ b/src/Commands/MakeSignalCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Commands;
+namespace SocialDept\AtpSignals\Commands;
 
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Commands/TestSignalCommand.php
+++ b/src/Commands/TestSignalCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SocialDept\Signals\Commands;
+namespace SocialDept\AtpSignals\Commands;
 
 use Illuminate\Console\Command;
 use InvalidArgumentException;
-use SocialDept\Signals\Events\CommitEvent;
-use SocialDept\Signals\Events\SignalEvent;
+use SocialDept\AtpSignals\Events\CommitEvent;
+use SocialDept\AtpSignals\Events\SignalEvent;
 
 class TestSignalCommand extends Command
 {

--- a/src/Contracts/CursorStore.php
+++ b/src/Contracts/CursorStore.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Contracts;
+namespace SocialDept\AtpSignals\Contracts;
 
 interface CursorStore
 {

--- a/src/Contracts/EventContract.php
+++ b/src/Contracts/EventContract.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Contracts;
+namespace SocialDept\AtpSignals\Contracts;
 
 interface EventContract
 {

--- a/src/Core/CAR.php
+++ b/src/Core/CAR.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\Core;
+namespace SocialDept\AtpSignals\Core;
 
-use SocialDept\Signals\CAR\BlockReader;
+use SocialDept\AtpSignals\CAR\BlockReader;
 
 /**
  * CAR (Content Addressable aRchive) facade.

--- a/src/Core/CBOR.php
+++ b/src/Core/CBOR.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\Core;
+namespace SocialDept\AtpSignals\Core;
 
-use SocialDept\Signals\CBOR\Decoder;
+use SocialDept\AtpSignals\CBOR\Decoder;
 
 /**
  * CBOR facade for simple decoding operations.

--- a/src/Core/CID.php
+++ b/src/Core/CID.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\Core;
+namespace SocialDept\AtpSignals\Core;
 
 use RuntimeException;
-use SocialDept\Signals\Binary\Reader;
-use SocialDept\Signals\Binary\Varint;
+use SocialDept\AtpSignals\Binary\Reader;
+use SocialDept\AtpSignals\Binary\Varint;
 
 /**
  * Content Identifier (CID) parser for IPLD.

--- a/src/Enums/SignalCommitOperation.php
+++ b/src/Enums/SignalCommitOperation.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Enums;
+namespace SocialDept\AtpSignals\Enums;
 
 enum SignalCommitOperation: string
 {

--- a/src/Enums/SignalEventType.php
+++ b/src/Enums/SignalEventType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Enums;
+namespace SocialDept\AtpSignals\Enums;
 
 enum SignalEventType: string
 {

--- a/src/Events/AccountEvent.php
+++ b/src/Events/AccountEvent.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace SocialDept\Signals\Events;
+namespace SocialDept\AtpSignals\Events;
 
-use SocialDept\Signals\Contracts\EventContract;
+use SocialDept\AtpSignals\Contracts\EventContract;
 
 class AccountEvent implements EventContract
 {

--- a/src/Events/CommitEvent.php
+++ b/src/Events/CommitEvent.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace SocialDept\Signals\Events;
+namespace SocialDept\AtpSignals\Events;
 
-use SocialDept\Signals\Contracts\EventContract;
-use SocialDept\Signals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Contracts\EventContract;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
 
 class CommitEvent implements EventContract
 {

--- a/src/Events/IdentityEvent.php
+++ b/src/Events/IdentityEvent.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace SocialDept\Signals\Events;
+namespace SocialDept\AtpSignals\Events;
 
-use SocialDept\Signals\Contracts\EventContract;
+use SocialDept\AtpSignals\Contracts\EventContract;
 
 class IdentityEvent implements EventContract
 {

--- a/src/Events/SignalEvent.php
+++ b/src/Events/SignalEvent.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace SocialDept\Signals\Events;
+namespace SocialDept\AtpSignals\Events;
 
-use SocialDept\Signals\Contracts\EventContract;
+use SocialDept\AtpSignals\Contracts\EventContract;
 
 class SignalEvent implements EventContract
 {
@@ -41,7 +41,7 @@ class SignalEvent implements EventContract
         return $this->commit?->record;
     }
 
-    public function getOperation(): ?\SocialDept\Signals\Enums\SignalCommitOperation
+    public function getOperation(): ?\SocialDept\AtpSignals\Enums\SignalCommitOperation
     {
         return $this->commit?->operation;
     }

--- a/src/Exceptions/ConnectionException.php
+++ b/src/Exceptions/ConnectionException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Exceptions;
+namespace SocialDept\AtpSignals\Exceptions;
 
 class ConnectionException extends \Exception
 {

--- a/src/Exceptions/SignalException.php
+++ b/src/Exceptions/SignalException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Exceptions;
+namespace SocialDept\AtpSignals\Exceptions;
 
 class SignalException extends \Exception
 {

--- a/src/Facades/Signal.php
+++ b/src/Facades/Signal.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace SocialDept\Signals\Facades;
+namespace SocialDept\AtpSignals\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use SocialDept\Signals\Services\SignalManager;
+use SocialDept\AtpSignals\Services\SignalManager;
 
 /**
  * @method static void start(?int $cursor = null)
  * @method static void stop()
  * @method static string getMode()
  *
- * @see \SocialDept\Signals\Services\SignalManager
+ * @see \SocialDept\AtpSignals\Services\SignalManager
  */
 class Signal extends Facade
 {

--- a/src/Jobs/ProcessSignalJob.php
+++ b/src/Jobs/ProcessSignalJob.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace SocialDept\Signals\Jobs;
+namespace SocialDept\AtpSignals\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class ProcessSignalJob implements ShouldQueue
 {

--- a/src/Services/EventDispatcher.php
+++ b/src/Services/EventDispatcher.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SocialDept\Signals\Services;
+namespace SocialDept\AtpSignals\Services;
 
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Jobs\ProcessSignalJob;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Jobs\ProcessSignalJob;
 
 class EventDispatcher
 {

--- a/src/Services/FirehoseConsumer.php
+++ b/src/Services/FirehoseConsumer.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace SocialDept\Signals\Services;
+namespace SocialDept\AtpSignals\Services;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
-use SocialDept\Signals\Contracts\CursorStore;
-use SocialDept\Signals\Core\CAR;
-use SocialDept\Signals\Core\CBOR;
-use SocialDept\Signals\Core\CID;
-use SocialDept\Signals\Events\AccountEvent;
-use SocialDept\Signals\Events\CommitEvent;
-use SocialDept\Signals\Events\IdentityEvent;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Exceptions\ConnectionException;
-use SocialDept\Signals\Support\WebSocketConnection;
+use SocialDept\AtpSignals\Contracts\CursorStore;
+use SocialDept\AtpSignals\Core\CAR;
+use SocialDept\AtpSignals\Core\CBOR;
+use SocialDept\AtpSignals\Core\CID;
+use SocialDept\AtpSignals\Events\AccountEvent;
+use SocialDept\AtpSignals\Events\CommitEvent;
+use SocialDept\AtpSignals\Events\IdentityEvent;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Exceptions\ConnectionException;
+use SocialDept\AtpSignals\Support\WebSocketConnection;
 
 class FirehoseConsumer
 {

--- a/src/Services/JetstreamConsumer.php
+++ b/src/Services/JetstreamConsumer.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SocialDept\Signals\Services;
+namespace SocialDept\AtpSignals\Services;
 
 use Illuminate\Support\Facades\Log;
-use SocialDept\Signals\Contracts\CursorStore;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Exceptions\ConnectionException;
-use SocialDept\Signals\Support\WebSocketConnection;
+use SocialDept\AtpSignals\Contracts\CursorStore;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Exceptions\ConnectionException;
+use SocialDept\AtpSignals\Support\WebSocketConnection;
 
 class JetstreamConsumer
 {

--- a/src/Services/SignalManager.php
+++ b/src/Services/SignalManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Services;
+namespace SocialDept\AtpSignals\Services;
 
 use InvalidArgumentException;
 

--- a/src/Services/SignalRegistry.php
+++ b/src/Services/SignalRegistry.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SocialDept\Signals\Services;
+namespace SocialDept\AtpSignals\Services;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use InvalidArgumentException;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class SignalRegistry
 {

--- a/src/SignalServiceProvider.php
+++ b/src/SignalServiceProvider.php
@@ -1,22 +1,22 @@
 <?php
 
-namespace SocialDept\Signals;
+namespace SocialDept\AtpSignals;
 
 use Illuminate\Support\ServiceProvider;
-use SocialDept\Signals\Commands\ConsumeCommand;
-use SocialDept\Signals\Commands\InstallCommand;
-use SocialDept\Signals\Commands\ListSignalsCommand;
-use SocialDept\Signals\Commands\MakeSignalCommand;
-use SocialDept\Signals\Commands\TestSignalCommand;
-use SocialDept\Signals\Contracts\CursorStore;
-use SocialDept\Signals\Services\EventDispatcher;
-use SocialDept\Signals\Services\FirehoseConsumer;
-use SocialDept\Signals\Services\JetstreamConsumer;
-use SocialDept\Signals\Services\SignalManager;
-use SocialDept\Signals\Services\SignalRegistry;
-use SocialDept\Signals\Storage\DatabaseCursorStore;
-use SocialDept\Signals\Storage\FileCursorStore;
-use SocialDept\Signals\Storage\RedisCursorStore;
+use SocialDept\AtpSignals\Commands\ConsumeCommand;
+use SocialDept\AtpSignals\Commands\InstallCommand;
+use SocialDept\AtpSignals\Commands\ListSignalsCommand;
+use SocialDept\AtpSignals\Commands\MakeSignalCommand;
+use SocialDept\AtpSignals\Commands\TestSignalCommand;
+use SocialDept\AtpSignals\Contracts\CursorStore;
+use SocialDept\AtpSignals\Services\EventDispatcher;
+use SocialDept\AtpSignals\Services\FirehoseConsumer;
+use SocialDept\AtpSignals\Services\JetstreamConsumer;
+use SocialDept\AtpSignals\Services\SignalManager;
+use SocialDept\AtpSignals\Services\SignalRegistry;
+use SocialDept\AtpSignals\Storage\DatabaseCursorStore;
+use SocialDept\AtpSignals\Storage\FileCursorStore;
+use SocialDept\AtpSignals\Storage\RedisCursorStore;
 
 class SignalServiceProvider extends ServiceProvider
 {

--- a/src/Signals/Signal.php
+++ b/src/Signals/Signal.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace SocialDept\Signals\Signals;
+namespace SocialDept\AtpSignals\Signals;
 
-use SocialDept\Signals\Events\SignalEvent;
+use SocialDept\AtpSignals\Events\SignalEvent;
 
 abstract class Signal
 {
     /**
      * Define which event types to listen for.
      *
-     * @return array<string|\SocialDept\Signals\Enums\SignalEventType>
+     * @return array<string|\SocialDept\AtpSignals\Enums\SignalEventType>
      */
     abstract public function eventTypes(): array;
 
@@ -42,7 +42,7 @@ abstract class Signal
      * - [SignalCommitOperation::Delete] - Only handle deletes
      * - null - Handle all operations (default)
      *
-     * @return array<string|\SocialDept\Signals\Enums\SignalCommitOperation>|null
+     * @return array<string|\SocialDept\AtpSignals\Enums\SignalCommitOperation>|null
      */
     public function operations(): ?array
     {

--- a/src/Storage/DatabaseCursorStore.php
+++ b/src/Storage/DatabaseCursorStore.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SocialDept\Signals\Storage;
+namespace SocialDept\AtpSignals\Storage;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
-use SocialDept\Signals\Contracts\CursorStore;
+use SocialDept\AtpSignals\Contracts\CursorStore;
 
 class DatabaseCursorStore implements CursorStore
 {

--- a/src/Storage/FileCursorStore.php
+++ b/src/Storage/FileCursorStore.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace SocialDept\Signals\Storage;
+namespace SocialDept\AtpSignals\Storage;
 
 use Illuminate\Support\Facades\File;
-use SocialDept\Signals\Contracts\CursorStore;
+use SocialDept\AtpSignals\Contracts\CursorStore;
 
 class FileCursorStore implements CursorStore
 {

--- a/src/Storage/RedisCursorStore.php
+++ b/src/Storage/RedisCursorStore.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace SocialDept\Signals\Storage;
+namespace SocialDept\AtpSignals\Storage;
 
 use Illuminate\Support\Facades\Redis;
-use SocialDept\Signals\Contracts\CursorStore;
+use SocialDept\AtpSignals\Contracts\CursorStore;
 
 class RedisCursorStore implements CursorStore
 {

--- a/src/Support/WebSocketConnection.php
+++ b/src/Support/WebSocketConnection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialDept\Signals\Support;
+namespace SocialDept\AtpSignals\Support;
 
 use Ratchet\Client\Connector;
 use Ratchet\Client\WebSocket;

--- a/stubs/signal.stub
+++ b/stubs/signal.stub
@@ -2,8 +2,8 @@
 
 namespace {{ namespace }};
 
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class {{ class }} extends Signal
 {

--- a/tests/Integration/FirehoseConsumerTest.php
+++ b/tests/Integration/FirehoseConsumerTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\Tests\Integration;
+namespace SocialDept\AtpSignals\Tests\Integration;
 
 use Orchestra\Testbench\TestCase;
-use SocialDept\Signals\Core\CAR;
-use SocialDept\Signals\Core\CBOR;
-use SocialDept\Signals\Core\CID;
+use SocialDept\AtpSignals\Core\CAR;
+use SocialDept\AtpSignals\Core\CBOR;
+use SocialDept\AtpSignals\Core\CID;
 
 class FirehoseConsumerTest extends TestCase
 {

--- a/tests/Unit/CBORTest.php
+++ b/tests/Unit/CBORTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\Tests\Unit;
+namespace SocialDept\AtpSignals\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use SocialDept\Signals\Core\CBOR;
-use SocialDept\Signals\Core\CID;
+use SocialDept\AtpSignals\Core\CBOR;
+use SocialDept\AtpSignals\Core\CID;
 
 class CBORTest extends TestCase
 {

--- a/tests/Unit/CIDTest.php
+++ b/tests/Unit/CIDTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\Tests\Unit;
+namespace SocialDept\AtpSignals\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use SocialDept\Signals\Core\CID;
+use SocialDept\AtpSignals\Core\CID;
 
 class CIDTest extends TestCase
 {

--- a/tests/Unit/SignalRegistryTest.php
+++ b/tests/Unit/SignalRegistryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SocialDept\Signals\Tests\Unit;
+namespace SocialDept\AtpSignals\Tests\Unit;
 
 use Orchestra\Testbench\TestCase;
-use SocialDept\Signals\Events\CommitEvent;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Services\SignalRegistry;
+use SocialDept\AtpSignals\Events\CommitEvent;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Services\SignalRegistry;
 
 class SignalRegistryTest extends TestCase
 {

--- a/tests/Unit/SignalTest.php
+++ b/tests/Unit/SignalTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SocialDept\Signals\Tests\Unit;
+namespace SocialDept\AtpSignals\Tests\Unit;
 
 use Orchestra\Testbench\TestCase;
-use SocialDept\Signals\Events\CommitEvent;
-use SocialDept\Signals\Events\SignalEvent;
-use SocialDept\Signals\Signals\Signal;
+use SocialDept\AtpSignals\Events\CommitEvent;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Signals\Signal;
 
 class SignalTest extends TestCase
 {
@@ -84,7 +84,7 @@ class SignalTest extends TestCase
         };
 
         // Create registry and register the signal
-        $registry = new \SocialDept\Signals\Services\SignalRegistry();
+        $registry = new \SocialDept\AtpSignals\Services\SignalRegistry();
         $registry->register($signalClass::class);
 
         // Test that it matches app.bsky.feed.post

--- a/tests/Unit/VarintTest.php
+++ b/tests/Unit/VarintTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace SocialDept\Signals\Tests\Unit;
+namespace SocialDept\AtpSignals\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use SocialDept\Signals\Binary\Varint;
+use SocialDept\AtpSignals\Binary\Varint;
 
 class VarintTest extends TestCase
 {


### PR DESCRIPTION
Renaming package namespace from `SocialDept\Signals` to `SocialDept\AtpSignals` to keep things consistent across SocialDept's AT Protocol packages.

⚠️ Major breaking changes