### PR TITLE
Add Jetstream v2 wire support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,10 @@ public function collections(): ?array
 
 Signal supports three modes for consuming AT Protocol events:
 
-- **Jetstream** (default) - Simplified JSON events with server-side filtering
+- **Jetstream** (default) - Simplified JSON events with server-side filtering. Speaks
+  either wire version: v1 (`time_us` cursors), or v2 (`SIGNAL_JETSTREAM_VERSION=2`)
+  with seq cursors, a server-side kinds filter, repo-divergence `sync` events, and
+  `CursorOutdated` advisories surfaced as a Laravel event
 - **Firehose** - Raw CBOR/CAR format with client-side filtering
 - **Obelisk** - Replayable delivery from a self-hosted record archive, by webhook or by polling
 

--- a/config/atp-signals.php
+++ b/config/atp-signals.php
@@ -31,6 +31,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Jetstream Wire Version
+    |--------------------------------------------------------------------------
+    |
+    | 1: the legacy wire (/subscribe, wantedCollections, time_us cursors).
+    | 2: subscribeEvents with collections/kinds filters, seq cursors (stored
+    |    under their own 'jetstream-v2' cursor key, never mixed with v1),
+    |    sync events, and OutdatedCursor advisories surfaced as the
+    |    SocialDept\AtpSignals\Events\CursorOutdated Laravel event.
+    |
+    | A fresh v2 consumer seeds its position from the v1 cursor when one
+    | exists: v2 reads cursor values >= 1e15 as unix-microsecond timestamps,
+    | which is exactly what a v1 time_us cursor is.
+    |
+    */
+    'jetstream_version' => (int) env('SIGNAL_JETSTREAM_VERSION', 1),
+
+    'websocket_url_v2' => env('SIGNAL_JETSTREAM_V2_URL', 'wss://jetstream.us-west.bsky.network'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Firehose Configuration
     |--------------------------------------------------------------------------
     |
@@ -181,6 +201,9 @@ return [
         'reconnect_delay' => 5, // Base delay in seconds (exponential backoff)
         'max_reconnect_delay' => 60, // Maximum delay in seconds
         'timeout' => 60, // seconds
+        // Reconnect when no message arrives for this long, catching dead
+        // connections the socket never reports closed. 0 disables.
+        'idle_timeout' => (int) env('SIGNAL_IDLE_TIMEOUT', 60),
     ],
 
     /*

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -17,7 +17,7 @@ Filtering lets you focus on what matters.
 
 Signal provides four filtering layers, applied in order:
 
-1. **Event Type Filtering** - Which kind of events (commit, identity, account)
+1. **Event Type Filtering** - Which kind of events (commit, identity, account, sync)
 2. **Collection Filtering** - Which AT Protocol collections
 3. **Operation Filtering** - Which operations (create, update, delete)
 4. **DID Filtering** - Which users
@@ -39,13 +39,14 @@ public function eventTypes(): array
 }
 ```
 
-**Three event types:**
+**Four event types:**
 
 | Type       | Description        | Use Cases                              |
 |------------|--------------------|----------------------------------------|
 | `commit`   | Repository changes | Posts, likes, follows, profile updates |
 | `identity` | Handle changes     | Username updates, account migrations   |
 | `account`  | Account status     | Deactivation, suspension               |
+| `sync`     | Repo divergence (Jetstream v2 only) | Re-fetch an account's records from its PDS |
 
 ### Multiple Event Types
 

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -37,6 +37,36 @@ SIGNAL_MODE=jetstream
 SIGNAL_JETSTREAM_URL=wss://jetstream2.us-east.bsky.network
 ```
 
+### Jetstream v2
+
+The v2 wire (`SIGNAL_JETSTREAM_VERSION=2`) speaks
+`/xrpc/network.bsky.jetstream.subscribeEvents` against the v2 hosts:
+
+```env
+SIGNAL_JETSTREAM_VERSION=2
+SIGNAL_JETSTREAM_V2_URL=wss://jetstream.us-west.bsky.network
+```
+
+What changes compared to v1:
+
+- **Seq cursors.** v2 identifies events by a monotonic `seq` instead of a
+  `time_us` timestamp. The cursor is stored under its own `jetstream-v2` key,
+  so the two versions never read each other's positions. A fresh v2 consumer
+  seeds itself from an existing v1 cursor automatically (the server reads
+  cursor values >= 1e15 as unix-microsecond timestamps, which is exactly what
+  a v1 cursor is), so migrating loses nothing.
+- **Sync events.** A fourth event kind marking a repo divergence: the
+  account's records should be re-fetched from its PDS rather than folded from
+  the stream. Handle it with `SignalEventType::Sync` in `eventTypes()` and
+  read it from `$event->sync`. The v1 wire never emits this kind.
+- **Kinds filter.** The consumer tells the server which event kinds your
+  signals handle, so unhandled kinds never leave the server.
+- **Gap advisories.** When a stored cursor falls outside the server's lookback
+  window, the server clamps the stream and the package fires the
+  `SocialDept\AtpSignals\Events\CursorOutdated` Laravel event. Listen for it
+  to trigger a backfill (e.g. from the Jetstream archive) instead of silently
+  losing the gap.
+
 ### Available Endpoints
 
 Jetstream has multiple regional endpoints:

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -198,7 +198,7 @@ public function handle(SignalEvent $event): void
     // User's DID (decentralized identifier)
     $did = $event->did; // "did:plc:z72i7hdynmk6r22z27h6tvur"
 
-    // Event type (commit, identity, account)
+    // Event type (commit, identity, account, sync)
     $kind = $event->kind;
 
     // Timestamp in microseconds

--- a/src/Enums/SignalEventType.php
+++ b/src/Enums/SignalEventType.php
@@ -7,4 +7,5 @@ enum SignalEventType: string
     case Commit = 'commit';
     case Identity = 'identity';
     case Account = 'account';
+    case Sync = 'sync';
 }

--- a/src/Events/CursorOutdated.php
+++ b/src/Events/CursorOutdated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SocialDept\AtpSignals\Events;
+
+/**
+ * Laravel event fired when a Jetstream v2 instance reports an OutdatedCursor
+ * advisory: the requested cursor fell outside the server's lookback window, so
+ * the stream was clamped and a gap exists between the stored position and
+ * where events resume. Listen for this to trigger an archive backfill instead
+ * of silently losing the gap.
+ */
+class CursorOutdated
+{
+    public function __construct(
+        public ?int $requestedCursor = null,
+        public ?string $message = null,
+    ) {
+    }
+}

--- a/src/Events/SignalEvent.php
+++ b/src/Events/SignalEvent.php
@@ -9,12 +9,14 @@ class SignalEvent implements EventContract
     public function __construct(
         public string $did,
         public int $timeUs,
-        public string $kind, // 'commit', 'identity', 'account'
+        public string $kind, // 'commit', 'identity', 'account', 'sync'
         public ?CommitEvent $commit = null,
         public ?IdentityEvent $identity = null,
         public ?AccountEvent $account = null,
         public ?bool $backfill = null, // null for jetstream/firehose, true/false for obelisk
         public ?string $cursor = null, // obelisk event id; null for jetstream/firehose
+        public ?SyncEvent $sync = null, // jetstream v2 only; v1 never emits sync
+        public ?int $seq = null, // jetstream v2 cursor; null on other transports
     ) {
     }
 
@@ -31,6 +33,11 @@ class SignalEvent implements EventContract
     public function isAccount(): bool
     {
         return $this->kind === 'account';
+    }
+
+    public function isSync(): bool
+    {
+        return $this->kind === 'sync';
     }
 
     public function getCollection(): ?string
@@ -62,6 +69,10 @@ class SignalEvent implements EventContract
             ? AccountEvent::fromArray($data['account'])
             : null;
 
+        $sync = isset($data['sync'])
+            ? SyncEvent::fromArray(['did' => $data['did'], ...$data['sync']])
+            : null;
+
         return new self(
             did: $data['did'],
             timeUs: $data['time_us'],
@@ -71,6 +82,8 @@ class SignalEvent implements EventContract
             account: $account,
             backfill: $data['backfill'] ?? null,
             cursor: isset($data['cursor']) ? (string) $data['cursor'] : null,
+            sync: $sync,
+            seq: isset($data['seq']) ? (int) $data['seq'] : null,
         );
     }
 
@@ -84,6 +97,14 @@ class SignalEvent implements EventContract
             'identity' => $this->identity?->toArray(),
             'account' => $this->account?->toArray(),
         ];
+
+        if ($this->sync !== null) {
+            $array['sync'] = $this->sync->toArray();
+        }
+
+        if ($this->seq !== null) {
+            $array['seq'] = $this->seq;
+        }
 
         if ($this->backfill !== null) {
             $array['backfill'] = $this->backfill;

--- a/src/Events/SyncEvent.php
+++ b/src/Events/SyncEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SocialDept\AtpSignals\Events;
+
+use SocialDept\AtpSignals\Contracts\EventContract;
+
+/**
+ * A repo divergence marker (Jetstream v2 only): the account's records can no
+ * longer be folded from the event stream alone and should be re-fetched from
+ * its PDS. The v1 wire never emits this kind.
+ */
+class SyncEvent implements EventContract
+{
+    public function __construct(
+        public string $did,
+        public ?string $rev = null,
+        public int $seq = 0,
+        public ?string $time = null,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            did: $data['did'],
+            rev: $data['rev'] ?? null,
+            seq: $data['seq'] ?? 0,
+            time: $data['time'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'did' => $this->did,
+            'rev' => $this->rev,
+            'seq' => $this->seq,
+            'time' => $this->time,
+        ];
+    }
+}

--- a/src/Services/JetstreamConsumer.php
+++ b/src/Services/JetstreamConsumer.php
@@ -3,9 +3,13 @@
 namespace SocialDept\AtpSignals\Services;
 
 use Illuminate\Support\Facades\Log;
+use React\EventLoop\TimerInterface;
 use SocialDept\AtpSignals\Contracts\CursorStore;
+use SocialDept\AtpSignals\Events\CursorOutdated;
 use SocialDept\AtpSignals\Events\SignalEvent;
 use SocialDept\AtpSignals\Exceptions\ConnectionException;
+use SocialDept\AtpSignals\Storage\CursorStoreFactory;
+use SocialDept\AtpSignals\Support\JetstreamV2Translator;
 use SocialDept\AtpSignals\Support\WebSocketConnection;
 
 class JetstreamConsumer
@@ -23,6 +27,10 @@ class JetstreamConsumer
     protected bool $shouldStop = false;
 
     protected ?\Exception $lastError = null;
+
+    protected ?TimerInterface $watchdogTimer = null;
+
+    protected float $lastMessageAt = 0;
 
     public function __construct(
         CursorStore $cursorStore,
@@ -48,6 +56,13 @@ class JetstreamConsumer
             $cursor = $this->cursorStore->get();
         }
 
+        // A v2 consumer with no position yet can seed from the v1 cursor: the
+        // server reads cursor values >= 1e15 as unix-microsecond timestamps,
+        // which is exactly what a v1 time_us cursor is.
+        if ($cursor === null && $this->version() === 2) {
+            $cursor = $this->seedCursorFromV1();
+        }
+
         // If cursor is explicitly 0, don't send it (fresh start)
         $url = $this->buildWebSocketUrl($cursor > 0 ? $cursor : null);
 
@@ -55,6 +70,7 @@ class JetstreamConsumer
             'url' => $url,
             'cursor' => $cursor > 0 ? $cursor : 'none (fresh start)',
             'mode' => 'jetstream',
+            'version' => $this->version(),
         ]);
 
         $this->connect($url);
@@ -77,6 +93,8 @@ class JetstreamConsumer
     {
         $this->shouldStop = true;
 
+        $this->disarmWatchdog();
+
         if ($this->connection) {
             $this->connection->close();
         }
@@ -85,15 +103,34 @@ class JetstreamConsumer
     }
 
     /**
-     * Connect to the Jetstream WebSocket.
+     * The Jetstream wire version to speak (1 or 2).
+     */
+    protected function version(): int
+    {
+        return (int) config('atp-signals.jetstream_version', 1);
+    }
+
+    /**
+     * Connect and run the event loop (blocking). Reconnects re-enter via
+     * establish() on a loop timer rather than calling this again.
      */
     protected function connect(string $url): void
+    {
+        $this->establish($url);
+        $this->connection->run();
+    }
+
+    /**
+     * Open a WebSocket connection asynchronously on the shared event loop.
+     */
+    protected function establish(string $url): void
     {
         $this->connection = new WebSocketConnection();
 
         // Set up event handlers
         $this->connection
             ->onMessage(function (string $message) {
+                $this->lastMessageAt = microtime(true);
                 $this->handleMessage($message);
             })
             ->onClose(function (?int $code, ?string $reason) {
@@ -103,10 +140,13 @@ class JetstreamConsumer
                 $this->handleError($e);
             });
 
+        $subProtocols = $this->version() === 2 ? ['xrpc.v1.json'] : [];
+
         // Connect to the WebSocket endpoint
-        $this->connection->connect($url)->then(
+        $this->connection->connect($url, $subProtocols)->then(
             function () {
                 $this->reconnectAttempts = 0;
+                $this->armWatchdog();
                 Log::info('[Signal] Connected to Jetstream successfully');
             },
             function (\Exception $e) {
@@ -119,9 +159,6 @@ class JetstreamConsumer
                 }
             }
         );
-
-        // Run the event loop (blocking)
-        $this->connection->run();
     }
 
     /**
@@ -134,6 +171,12 @@ class JetstreamConsumer
 
             if (! $data) {
                 Log::warning('[Signal] Failed to decode message');
+
+                return;
+            }
+
+            if ($this->version() === 2) {
+                $this->handleV2Payload(JetstreamV2Translator::payload($data));
 
                 return;
             }
@@ -152,6 +195,44 @@ class JetstreamConsumer
                 'trace' => $e->getTraceAsString(),
             ]);
         }
+    }
+
+    /**
+     * Handle a decoded Jetstream v2 payload.
+     */
+    protected function handleV2Payload(array $payload): void
+    {
+        if (JetstreamV2Translator::isInfo($payload)) {
+            Log::warning('[Signal] Jetstream advisory', [
+                'name' => $payload['name'] ?? null,
+                'message' => $payload['message'] ?? null,
+            ]);
+
+            if (($payload['name'] ?? null) === 'OutdatedCursor') {
+                event(new CursorOutdated(
+                    requestedCursor: $this->cursorStore->get(),
+                    message: $payload['message'] ?? null,
+                ));
+            }
+
+            return;
+        }
+
+        $event = JetstreamV2Translator::toSignalEvent($payload);
+
+        if ($event === null) {
+            Log::warning('[Signal] Unrecognized v2 payload', [
+                'type' => $payload['$type'] ?? null,
+            ]);
+
+            return;
+        }
+
+        if ($event->seq !== null) {
+            $this->cursorStore->set($event->seq);
+        }
+
+        $this->eventDispatcher->dispatch($event);
     }
 
     /**
@@ -183,7 +264,9 @@ class JetstreamConsumer
     }
 
     /**
-     * Attempt to reconnect to the Jetstream with exponential backoff.
+     * Schedule a reconnect on the event loop with exponential backoff. A loop
+     * timer (rather than a blocking sleep) keeps the loop responsive and the
+     * call stack flat across repeated reconnects.
      */
     protected function attemptReconnect(): void
     {
@@ -193,6 +276,7 @@ class JetstreamConsumer
             Log::error('[Signal] Max reconnection attempts reached');
 
             $this->lastError = new ConnectionException('Failed to reconnect to Jetstream after '.$maxAttempts.' attempts');
+            $this->disarmWatchdog();
             $this->connection?->stop();
 
             return;
@@ -215,12 +299,72 @@ class JetstreamConsumer
             'delay' => $delay,
         ]);
 
-        sleep($delay);
+        $this->connection->getLoop()->addTimer($delay, function () {
+            if ($this->shouldStop) {
+                return;
+            }
 
-        $cursor = $this->cursorStore->get();
-        $url = $this->buildWebSocketUrl($cursor);
+            $cursor = $this->cursorStore->get();
+            $this->establish($this->buildWebSocketUrl($cursor));
+        });
+    }
 
-        $this->connect($url);
+    /**
+     * Watch for silent dead connections: a Jetstream that sends nothing for
+     * longer than the idle timeout is treated as gone and reconnected, even
+     * when the socket never reported a close.
+     */
+    protected function armWatchdog(): void
+    {
+        $timeout = (int) config('atp-signals.connection.idle_timeout', 60);
+
+        if ($timeout <= 0) {
+            return;
+        }
+
+        $this->disarmWatchdog();
+        $this->lastMessageAt = microtime(true);
+
+        $interval = max(1, (int) ceil($timeout / 4));
+
+        $this->watchdogTimer = $this->connection->getLoop()->addPeriodicTimer($interval, function () use ($timeout) {
+            if ($this->shouldStop || ! $this->connection?->isConnected()) {
+                return;
+            }
+
+            if (microtime(true) - $this->lastMessageAt > $timeout) {
+                Log::warning('[Signal] No messages within idle timeout; reconnecting', [
+                    'idle_timeout' => $timeout,
+                ]);
+
+                $this->connection->close();
+            }
+        });
+    }
+
+    protected function disarmWatchdog(): void
+    {
+        if ($this->watchdogTimer && $this->connection) {
+            $this->connection->getLoop()->cancelTimer($this->watchdogTimer);
+        }
+
+        $this->watchdogTimer = null;
+    }
+
+    /**
+     * Seed a fresh v2 cursor from the legacy v1 position, if one exists.
+     */
+    protected function seedCursorFromV1(): ?int
+    {
+        $timeUs = CursorStoreFactory::make()->get();
+
+        if ($timeUs !== null && $timeUs > 0) {
+            Log::info('[Signal] Seeding v2 cursor from the v1 time_us position', [
+                'time_us' => $timeUs,
+            ]);
+        }
+
+        return $timeUs;
     }
 
     /**
@@ -228,6 +372,10 @@ class JetstreamConsumer
      */
     protected function buildWebSocketUrl(?int $cursor = null): string
     {
+        if ($this->version() === 2) {
+            return $this->buildV2WebSocketUrl($cursor);
+        }
+
         $baseUrl = config('atp-signals.websocket_url', 'wss://jetstream2.us-east.bsky.network');
         $url = rtrim($baseUrl, '/').'/subscribe';
 
@@ -266,6 +414,61 @@ class JetstreamConsumer
                     $params[] = 'wantedCollections='.$encoded;
                 }
             }
+        }
+
+        if (! empty($params)) {
+            $url .= '?'.implode('&', $params);
+        }
+
+        return $url;
+    }
+
+    /**
+     * Build the Jetstream v2 subscribeEvents URL. v2 renames the filters
+     * (collections, kinds) and adds a kinds filter so the server can skip
+     * event kinds no signal handles.
+     */
+    protected function buildV2WebSocketUrl(?int $cursor = null): string
+    {
+        $baseUrl = config('atp-signals.websocket_url_v2', 'wss://jetstream.us-west.bsky.network');
+        $url = rtrim($baseUrl, '/').'/xrpc/network.bsky.jetstream.subscribeEvents';
+
+        $params = [];
+
+        if ($cursor !== null) {
+            $params[] = 'cursor='.$cursor;
+        }
+
+        $signals = $this->signalRegistry->all();
+
+        $kinds = $signals
+            ->flatMap(fn ($signal) => $signal->eventTypes())
+            ->map(fn ($kind) => $kind instanceof \BackedEnum ? $kind->value : $kind)
+            ->unique()
+            ->filter()
+            ->values();
+
+        // A collections filter constrains commits only, so it is meaningless
+        // (and rejected by the server) when no signal handles commits.
+        $wantsCommits = $kinds->contains('commit');
+        $hasWildcardSignal = $signals->contains(fn ($signal) => $signal->collections() === null);
+
+        if ($wantsCommits && ! $hasWildcardSignal) {
+            $collections = $signals
+                ->flatMap(fn ($signal) => $signal->collections() ?? [])
+                ->unique()
+                ->filter()
+                ->values();
+
+            foreach ($collections as $collection) {
+                // Don't encode wildcards - Jetstream expects literal *
+                $encoded = str_replace('%2A', '*', urlencode($collection));
+                $params[] = 'collections='.$encoded;
+            }
+        }
+
+        foreach ($kinds as $kind) {
+            $params[] = 'kinds='.$kind;
         }
 
         if (! empty($params)) {

--- a/src/SignalServiceProvider.php
+++ b/src/SignalServiceProvider.php
@@ -34,8 +34,11 @@ class SignalServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/atp-signals.php', 'atp-signals');
 
-        // Register cursor store
-        $this->app->singleton(CursorStore::class, fn () => $this->makeCursorStore());
+        // Register cursor store. v2 seq cursors live under their own key:
+        // a v1 time_us and a v2 seq must never be read as one another.
+        $this->app->singleton(CursorStore::class, fn () => $this->makeCursorStore(
+            (int) config('atp-signals.jetstream_version', 1) === 2 ? 'jetstream-v2' : null
+        ));
 
         // Register signal registry
         $this->app->singleton(SignalRegistry::class, function ($app) {

--- a/src/Support/JetstreamV2Translator.php
+++ b/src/Support/JetstreamV2Translator.php
@@ -71,21 +71,23 @@ class JetstreamV2Translator
                 break;
 
             case 'identity':
-                $identity = IdentityEvent::fromArray($payload);
+                $identity = IdentityEvent::fromArray(self::nested($payload, 'identity'));
 
                 break;
 
             case 'account':
-                if (! isset($payload['active'])) {
+                $account = self::nested($payload, 'account');
+
+                if (! isset($account['active'])) {
                     return null;
                 }
 
-                $account = AccountEvent::fromArray($payload);
+                $account = AccountEvent::fromArray($account);
 
                 break;
 
             case 'sync':
-                $sync = SyncEvent::fromArray($payload);
+                $sync = SyncEvent::fromArray(self::nested($payload, 'sync'));
 
                 break;
         }
@@ -100,6 +102,22 @@ class JetstreamV2Translator
             sync: $sync,
             seq: isset($payload['seq']) ? (int) $payload['seq'] : null,
         );
+    }
+
+    /**
+     * Identity, account, and sync payloads nest their object under the kind's
+     * key (commit fields sit flat). Falls back to the payload itself so a
+     * flat variant still translates.
+     */
+    protected static function nested(array $payload, string $key): array
+    {
+        $inner = $payload[$key] ?? null;
+
+        if (! is_array($inner) || $inner === []) {
+            return $payload;
+        }
+
+        return $inner + ['did' => $payload['did']];
     }
 
     protected static function kind(array $payload): ?string

--- a/src/Support/JetstreamV2Translator.php
+++ b/src/Support/JetstreamV2Translator.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace SocialDept\AtpSignals\Support;
+
+use SocialDept\AtpSignals\Events\AccountEvent;
+use SocialDept\AtpSignals\Events\CommitEvent;
+use SocialDept\AtpSignals\Events\IdentityEvent;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Events\SyncEvent;
+
+/**
+ * Maps Jetstream v2 wire payloads onto SignalEvent.
+ *
+ * The v2 wire differs from v1: frames arrive as {"payload": {...}} envelopes
+ * (xrpc.v1.json subprotocol), the payload carries a "$type" of
+ * network.bsky.jetstream.subscribeEvents#<kind>, commit fields sit flat on the
+ * payload instead of nested under "commit", the cursor is a "seq" instead of
+ * "time_us", and a "sync" kind exists that v1 never emits.
+ */
+class JetstreamV2Translator
+{
+    protected const KINDS = ['commit', 'identity', 'account', 'sync'];
+
+    /**
+     * Extract the payload from a decoded v2 frame (tolerates unenveloped
+     * payloads).
+     */
+    public static function payload(array $frame): array
+    {
+        $payload = $frame['payload'] ?? $frame;
+
+        return is_array($payload) ? $payload : [];
+    }
+
+    /**
+     * Whether the payload is a seq-less server advisory (#info frame).
+     */
+    public static function isInfo(array $payload): bool
+    {
+        return str_ends_with($payload['$type'] ?? '', '#info');
+    }
+
+    public static function toSignalEvent(array $payload): ?SignalEvent
+    {
+        $kind = self::kind($payload);
+
+        if ($kind === null || ! isset($payload['did'])) {
+            return null;
+        }
+
+        $commit = null;
+        $identity = null;
+        $account = null;
+        $sync = null;
+
+        switch ($kind) {
+            case 'commit':
+                if (! isset($payload['operation'], $payload['collection'], $payload['rkey'])) {
+                    return null;
+                }
+
+                $commit = CommitEvent::fromArray([
+                    'rev' => $payload['rev'] ?? '',
+                    'operation' => $payload['operation'],
+                    'collection' => $payload['collection'],
+                    'rkey' => $payload['rkey'],
+                    'record' => $payload['record'] ?? null,
+                    'cid' => $payload['cid'] ?? null,
+                ]);
+
+                break;
+
+            case 'identity':
+                $identity = IdentityEvent::fromArray($payload);
+
+                break;
+
+            case 'account':
+                if (! isset($payload['active'])) {
+                    return null;
+                }
+
+                $account = AccountEvent::fromArray($payload);
+
+                break;
+
+            case 'sync':
+                $sync = SyncEvent::fromArray($payload);
+
+                break;
+        }
+
+        return new SignalEvent(
+            did: $payload['did'],
+            timeUs: self::timeUs($payload['time'] ?? null) ?? 0,
+            kind: $kind,
+            commit: $commit,
+            identity: $identity,
+            account: $account,
+            sync: $sync,
+            seq: isset($payload['seq']) ? (int) $payload['seq'] : null,
+        );
+    }
+
+    protected static function kind(array $payload): ?string
+    {
+        $type = $payload['$type'] ?? null;
+
+        $kind = $type !== null && str_contains($type, '#')
+            ? substr($type, strpos($type, '#') + 1)
+            : ($payload['kind'] ?? null);
+
+        return in_array($kind, self::KINDS, true) ? $kind : null;
+    }
+
+    protected static function timeUs(?string $time): ?int
+    {
+        if (! $time) {
+            return null;
+        }
+
+        try {
+            return (int) (new \DateTimeImmutable($time))->format('Uu');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Support/WebSocketConnection.php
+++ b/src/Support/WebSocketConnection.php
@@ -29,12 +29,15 @@ class WebSocketConnection
 
     /**
      * Connect to a WebSocket endpoint.
+     *
+     * @param  array  $subProtocols  WebSocket subprotocols to negotiate
+     *                               (e.g. ['xrpc.v1.json'] for Jetstream v2)
      */
-    public function connect(string $url): PromiseInterface
+    public function connect(string $url, array $subProtocols = []): PromiseInterface
     {
         $connector = new Connector($this->loop);
 
-        return $connector($url)->then(
+        return $connector($url, $subProtocols)->then(
             function (WebSocket $conn) {
                 $this->connection = $conn;
                 $this->connected = true;

--- a/tests/Unit/JetstreamV2Test.php
+++ b/tests/Unit/JetstreamV2Test.php
@@ -57,7 +57,7 @@ class JetstreamV2Test extends TestCase
             '$type' => 'network.bsky.jetstream.subscribeEvents#sync',
             'did' => 'did:plc:diverged',
             'seq' => 7,
-            'rev' => '3krev',
+            'sync' => ['did' => 'did:plc:diverged', 'rev' => '3krev', 'seq' => 99],
         ]);
 
         $this->assertTrue($sync->isSync());
@@ -68,7 +68,7 @@ class JetstreamV2Test extends TestCase
             '$type' => 'network.bsky.jetstream.subscribeEvents#identity',
             'did' => 'did:plc:renamed',
             'seq' => 8,
-            'handle' => 'new.example.com',
+            'identity' => ['did' => 'did:plc:renamed', 'handle' => 'new.example.com', 'seq' => 99],
         ]);
 
         $this->assertTrue($identity->isIdentity());
@@ -78,13 +78,28 @@ class JetstreamV2Test extends TestCase
             '$type' => 'network.bsky.jetstream.subscribeEvents#account',
             'did' => 'did:plc:gone',
             'seq' => 9,
-            'active' => false,
-            'status' => 'deleted',
+            'account' => ['did' => 'did:plc:gone', 'active' => false, 'status' => 'deleted', 'seq' => 99],
         ]);
 
         $this->assertTrue($account->isAccount());
         $this->assertFalse($account->account->active);
         $this->assertSame('deleted', $account->account->status);
+    }
+
+    #[Test]
+    public function it_translates_flat_payloads_as_a_fallback()
+    {
+        $account = JetstreamV2Translator::toSignalEvent([
+            '$type' => 'network.bsky.jetstream.subscribeEvents#account',
+            'did' => 'did:plc:gone',
+            'seq' => 9,
+            'active' => false,
+            'status' => 'deactivated',
+        ]);
+
+        $this->assertTrue($account->isAccount());
+        $this->assertFalse($account->account->active);
+        $this->assertSame('deactivated', $account->account->status);
     }
 
     #[Test]

--- a/tests/Unit/JetstreamV2Test.php
+++ b/tests/Unit/JetstreamV2Test.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace SocialDept\AtpSignals\Tests\Unit;
+
+use Mockery;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use SocialDept\AtpSignals\Contracts\CursorStore;
+use SocialDept\AtpSignals\Enums\SignalCommitOperation;
+use SocialDept\AtpSignals\Events\SignalEvent;
+use SocialDept\AtpSignals\Services\EventDispatcher;
+use SocialDept\AtpSignals\Services\JetstreamConsumer;
+use SocialDept\AtpSignals\Services\SignalRegistry;
+use SocialDept\AtpSignals\Signals\Signal;
+use SocialDept\AtpSignals\Storage\FileCursorStore;
+use SocialDept\AtpSignals\Support\JetstreamV2Translator;
+
+class JetstreamV2Test extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_translates_a_v2_commit_payload_with_flat_fields()
+    {
+        $event = JetstreamV2Translator::toSignalEvent([
+            '$type' => 'network.bsky.jetstream.subscribeEvents#commit',
+            'did' => 'did:plc:example',
+            'seq' => 42,
+            'time' => '2026-08-14T12:00:00.000Z',
+            'operation' => 'create',
+            'collection' => 'app.bsky.feed.post',
+            'rkey' => '3kabc',
+            'rev' => '3krev',
+            'cid' => 'bafyexample',
+            'record' => ['$type' => 'app.bsky.feed.post', 'text' => 'hi'],
+        ]);
+
+        $this->assertNotNull($event);
+        $this->assertTrue($event->isCommit());
+        $this->assertSame('did:plc:example', $event->did);
+        $this->assertSame(42, $event->seq);
+        $this->assertSame('app.bsky.feed.post', $event->getCollection());
+        $this->assertSame(SignalCommitOperation::Create, $event->getOperation());
+        $this->assertSame('3kabc', $event->commit->rkey);
+        $this->assertSame('hi', $event->getRecord()->text);
+        $this->assertSame(1786708800000000, $event->timeUs);
+    }
+
+    #[Test]
+    public function it_translates_sync_identity_and_account_payloads()
+    {
+        $sync = JetstreamV2Translator::toSignalEvent([
+            '$type' => 'network.bsky.jetstream.subscribeEvents#sync',
+            'did' => 'did:plc:diverged',
+            'seq' => 7,
+            'rev' => '3krev',
+        ]);
+
+        $this->assertTrue($sync->isSync());
+        $this->assertSame('3krev', $sync->sync->rev);
+        $this->assertSame(7, $sync->seq);
+
+        $identity = JetstreamV2Translator::toSignalEvent([
+            '$type' => 'network.bsky.jetstream.subscribeEvents#identity',
+            'did' => 'did:plc:renamed',
+            'seq' => 8,
+            'handle' => 'new.example.com',
+        ]);
+
+        $this->assertTrue($identity->isIdentity());
+        $this->assertSame('new.example.com', $identity->identity->handle);
+
+        $account = JetstreamV2Translator::toSignalEvent([
+            '$type' => 'network.bsky.jetstream.subscribeEvents#account',
+            'did' => 'did:plc:gone',
+            'seq' => 9,
+            'active' => false,
+            'status' => 'deleted',
+        ]);
+
+        $this->assertTrue($account->isAccount());
+        $this->assertFalse($account->account->active);
+        $this->assertSame('deleted', $account->account->status);
+    }
+
+    #[Test]
+    public function it_unwraps_envelopes_and_recognizes_info_frames()
+    {
+        $frame = [
+            'payload' => [
+                '$type' => 'network.bsky.jetstream.subscribeEvents#info',
+                'name' => 'OutdatedCursor',
+                'message' => 'requested cursor exceeded limit',
+            ],
+        ];
+
+        $payload = JetstreamV2Translator::payload($frame);
+
+        $this->assertTrue(JetstreamV2Translator::isInfo($payload));
+        $this->assertNull(JetstreamV2Translator::toSignalEvent($payload));
+
+        $bare = ['$type' => 'network.bsky.jetstream.subscribeEvents#sync', 'did' => 'did:plc:x', 'seq' => 1];
+        $this->assertSame($bare, JetstreamV2Translator::payload($bare));
+    }
+
+    #[Test]
+    public function it_rejects_payloads_missing_required_fields()
+    {
+        $this->assertNull(JetstreamV2Translator::toSignalEvent([
+            '$type' => 'network.bsky.jetstream.subscribeEvents#commit',
+            'did' => 'did:plc:example',
+            'seq' => 1,
+        ]));
+
+        $this->assertNull(JetstreamV2Translator::toSignalEvent([
+            '$type' => 'network.bsky.jetstream.subscribeEvents#unknown',
+            'did' => 'did:plc:example',
+        ]));
+    }
+
+    #[Test]
+    public function it_builds_a_v2_url_with_collections_kinds_and_cursor()
+    {
+        config(['atp-signals.jetstream_version' => 2]);
+
+        $signal = new class () extends Signal {
+            public function eventTypes(): array
+            {
+                return ['commit', 'sync'];
+            }
+
+            public function collections(): ?array
+            {
+                return ['site.standard.document', 'blog.pckt.*'];
+            }
+
+            public function handle(SignalEvent $event): void
+            {
+                //
+            }
+        };
+
+        $registry = new SignalRegistry();
+        $registry->register($signal::class);
+
+        $consumer = $this->createConsumer($registry);
+        $url = $this->invokeMethod($consumer, 'buildWebSocketUrl', [123456]);
+
+        $this->assertStringStartsWith('wss://jetstream.us-west.bsky.network/xrpc/network.bsky.jetstream.subscribeEvents?', $url);
+        $this->assertStringContainsString('cursor=123456', $url);
+        $this->assertStringContainsString('collections=site.standard.document', $url);
+        $this->assertStringContainsString('collections=blog.pckt.*', $url);
+        $this->assertStringContainsString('kinds=commit', $url);
+        $this->assertStringContainsString('kinds=sync', $url);
+        $this->assertStringNotContainsString('wantedCollections', $url);
+    }
+
+    #[Test]
+    public function it_omits_the_collections_filter_when_no_signal_handles_commits()
+    {
+        config(['atp-signals.jetstream_version' => 2]);
+
+        $signal = new class () extends Signal {
+            public function eventTypes(): array
+            {
+                return ['sync'];
+            }
+
+            public function collections(): ?array
+            {
+                return ['site.standard.document'];
+            }
+
+            public function handle(SignalEvent $event): void
+            {
+                //
+            }
+        };
+
+        $registry = new SignalRegistry();
+        $registry->register($signal::class);
+
+        $consumer = $this->createConsumer($registry);
+        $url = $this->invokeMethod($consumer, 'buildWebSocketUrl', [null]);
+
+        $this->assertStringNotContainsString('collections=', $url);
+        $this->assertStringContainsString('kinds=sync', $url);
+    }
+
+    #[Test]
+    public function it_seeds_a_fresh_v2_cursor_from_the_v1_time_us_position()
+    {
+        config([
+            'atp-signals.jetstream_version' => 2,
+            'atp-signals.cursor_storage' => 'file',
+            'atp-signals.cursor_config.file.path' => sys_get_temp_dir().'/atp-signals-v2-seed-test/cursor.json',
+        ]);
+
+        $v1Store = new FileCursorStore();
+        $v1Store->set(1786363200000000);
+
+        $consumer = $this->createConsumer(new SignalRegistry());
+        $seed = $this->invokeMethod($consumer, 'seedCursorFromV1');
+
+        $this->assertSame(1786363200000000, $seed);
+
+        $v1Store->clear();
+    }
+
+    protected function createConsumer(SignalRegistry $registry): JetstreamConsumer
+    {
+        $cursorStore = Mockery::mock(CursorStore::class);
+        $eventDispatcher = Mockery::mock(EventDispatcher::class);
+
+        return new JetstreamConsumer($cursorStore, $registry, $eventDispatcher);
+    }
+
+    protected function invokeMethod(&$object, $methodName, array $parameters = [])
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+}


### PR DESCRIPTION
## What

`SIGNAL_JETSTREAM_VERSION=2` switches the Jetstream consumer to the v2 wire (`/xrpc/network.bsky.jetstream.subscribeEvents`), while v1 remains the default with behavior unchanged.

- **v2 wire**: negotiates the `xrpc.v1.json` subprotocol and translates v2 frames (envelope + `$type`-tagged payloads; commit fields flat, identity/account/sync nested — shapes verified against live captured frames) onto the existing `SignalEvent` API, so signals work unmodified on either version
- **Filters**: `collections` and `kinds` params built from registered signals, so the server skips event kinds no signal handles
- **Seq cursors**: stored under a dedicated `jetstream-v2` cursor key — a v1 `time_us` and a v2 `seq` must never be read as one another. A fresh v2 consumer seeds from an existing v1 cursor (the server reads values >= 1e15 as unix-µs timestamps, which a v1 cursor is), so migration loses no events
- **Sync events**: new `SyncEvent` + `SignalEventType::Sync` for v2's repo-divergence markers (v1 never emits them)
- **Gap advisories**: an `OutdatedCursor` advisory fires the `CursorOutdated` Laravel event so applications can backfill the gap instead of silently losing it

## Transport hardening (both versions)

- Reconnects are scheduled on the event loop with the existing backoff, replacing a blocking `sleep()` that recursed into nested loop runs
- An idle watchdog (`connection.idle_timeout`, default 60s) reconnects when the stream goes silent, catching dead connections the socket never reports closed — a failure mode we've hit where the consumer busy-spun with a frozen cursor

## Testing

71 tests pass (`vendor/bin/phpunit`), including new coverage for the v2 translator (all four kinds, envelope unwrapping, info frames, flat fallback, malformed payloads), v2 URL building, and v1→v2 cursor seeding. `php-cs-fixer` clean.

Verified against the live wire: payload shapes were confirmed from captured frames, and the consumer runs cleanly against `jetstream.us-west.bsky.network` (connect, cursor advancement, all four event kinds translating).

Docs updated: README modes list, `docs/modes.md` (new v2 section), `docs/filtering.md`, `docs/signals.md`.
