### PR TITLE
Run tests on PHP 8.3 and 8.4 instead of the unsupported 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    name: Tests (PHP 8.2 - Laravel 12)
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3', '8.4']
+
+    name: Tests (PHP ${{ matrix.php }} - Laravel 12)
 
     steps:
       - name: Checkout code
@@ -17,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: ${{ matrix.php }}
           extensions: gmp, mbstring, json
           coverage: none
 


### PR DESCRIPTION
## What

`tests.yml` pinned `php-version: 8.2` while `composer.json` has required `php ^8.3` since `atp-cbor` was bumped to `^0.2`. The job has failed in **Install dependencies**, before running a single test, on every pull request since — including #13.

```
Problem 1
  - Root composer.json requires php ^8.3 but your php version (8.2.33) does not satisfy that requirement.
Problem 2
  - Root composer.json requires socialdept/atp-cbor ^0.2 -> satisfiable by socialdept/atp-cbor[v0.2.0, v0.2.1, v0.2.2].
  - socialdept/atp-cbor[v0.2.0, ..., v0.2.2] require php ^8.3 -> your php version (8.2.33) does not satisfy that requirement.
```

So the red check on recent PRs reflects the workflow config, not the changes under review.

## Change

Run the matrix on **8.3** and **8.4** instead:

- **8.3** is the floor `composer.json` requires
- **8.4** is what the suite is developed against locally

`fail-fast: false`, so one version failing still reports the other. `code-style.yml` was already on 8.3, so this brings the two workflows back in line.

## Not covered here

The package declares `illuminate/*: ^11.0|^12.0|^13.0` but this workflow still tests Laravel 12 only. Widening the matrix to 11 and 13 is worth doing, but separately — it may surface real incompatibilities rather than simply turning the job green, and that deserves its own review.

## Testing

Full suite on PHP 8.4: **75 tests, 201 assertions, green.** `php-cs-fixer` clean.
