### PR TITLE
Fix v2 cursor resolution on reconnect and scope its key to Jetstream

### DIFF
--- a/src/Services/JetstreamConsumer.php
+++ b/src/Services/JetstreamConsumer.php
@@ -50,25 +50,14 @@ class JetstreamConsumer
         $this->shouldStop = false;
         $this->lastError = null;
 
-        // Get cursor from storage if not explicitly provided
         // null = use stored cursor, 0 = start fresh (no cursor), >0 = specific cursor
-        if ($cursor === null) {
-            $cursor = $this->cursorStore->get();
-        }
+        $cursor = $this->resolveCursor($cursor);
 
-        // A v2 consumer with no position yet can seed from the v1 cursor: the
-        // server reads cursor values >= 1e15 as unix-microsecond timestamps,
-        // which is exactly what a v1 time_us cursor is.
-        if ($cursor === null && $this->version() === 2) {
-            $cursor = $this->seedCursorFromV1();
-        }
-
-        // If cursor is explicitly 0, don't send it (fresh start)
-        $url = $this->buildWebSocketUrl($cursor > 0 ? $cursor : null);
+        $url = $this->buildWebSocketUrl($cursor);
 
         Log::info('[Signal] Starting Jetstream consumer', [
             'url' => $url,
-            'cursor' => $cursor > 0 ? $cursor : 'none (fresh start)',
+            'cursor' => $cursor ?? 'none (fresh start)',
             'mode' => 'jetstream',
             'version' => $this->version(),
         ]);
@@ -304,8 +293,7 @@ class JetstreamConsumer
                 return;
             }
 
-            $cursor = $this->cursorStore->get();
-            $this->establish($this->buildWebSocketUrl($cursor));
+            $this->establish($this->buildWebSocketUrl($this->resolveCursor()));
         });
     }
 
@@ -349,6 +337,34 @@ class JetstreamConsumer
         }
 
         $this->watchdogTimer = null;
+    }
+
+    /**
+     * Resolve the position to connect from.
+     *
+     * Used by both the initial start and every reconnect: a reconnect that
+     * resolved the cursor differently would silently restart from live once
+     * the stored position is still empty, losing the v1 seed it was given.
+     *
+     * @param  int|null  $cursor  null = use the stored position, 0 = start
+     *                            fresh, >0 = an explicit position
+     * @return int|null The cursor to send, or null to start from live
+     */
+    protected function resolveCursor(?int $cursor = null): ?int
+    {
+        if ($cursor === null) {
+            $cursor = $this->cursorStore->get();
+        }
+
+        // A v2 consumer with no position yet can seed from the v1 cursor: the
+        // server reads cursor values >= 1e15 as unix-microsecond timestamps,
+        // which is exactly what a v1 time_us cursor is.
+        if ($cursor === null && $this->version() === 2) {
+            $cursor = $this->seedCursorFromV1();
+        }
+
+        // A cursor of 0 means "fresh start" here, so it is not sent.
+        return $cursor > 0 ? $cursor : null;
     }
 
     /**

--- a/src/SignalServiceProvider.php
+++ b/src/SignalServiceProvider.php
@@ -34,11 +34,10 @@ class SignalServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/atp-signals.php', 'atp-signals');
 
-        // Register cursor store. v2 seq cursors live under their own key:
-        // a v1 time_us and a v2 seq must never be read as one another.
-        $this->app->singleton(CursorStore::class, fn () => $this->makeCursorStore(
-            (int) config('atp-signals.jetstream_version', 1) === 2 ? 'jetstream-v2' : null
-        ));
+        // The default cursor store: the shared slot the firehose consumer and
+        // anything resolving the contract directly both use. Jetstream scopes
+        // its own key below rather than rebinding this one.
+        $this->app->singleton(CursorStore::class, fn () => $this->makeCursorStore());
 
         // Register signal registry
         $this->app->singleton(SignalRegistry::class, function ($app) {
@@ -63,7 +62,13 @@ class SignalServiceProvider extends ServiceProvider
         // Register Jetstream consumer
         $this->app->singleton(JetstreamConsumer::class, function ($app) {
             return new JetstreamConsumer(
-                $app->make(CursorStore::class),
+                // v2 seq cursors live under their own key: a v1 time_us and a
+                // v2 seq must never be read as one another. Scoped to this
+                // consumer so the firehose keeps its own position, the same
+                // way ObeliskConsumer takes its own store below.
+                $this->makeCursorStore(
+                    (int) config('atp-signals.jetstream_version', 1) === 2 ? 'jetstream-v2' : null
+                ),
                 $app->make(SignalRegistry::class),
                 $app->make(EventDispatcher::class),
             );

--- a/tests/Unit/JetstreamV2CursorTest.php
+++ b/tests/Unit/JetstreamV2CursorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SocialDept\AtpSignals\Tests\Unit;
+
+use Mockery;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use SocialDept\AtpSignals\Contracts\CursorStore;
+use SocialDept\AtpSignals\Services\EventDispatcher;
+use SocialDept\AtpSignals\Services\FirehoseConsumer;
+use SocialDept\AtpSignals\Services\JetstreamConsumer;
+use SocialDept\AtpSignals\Services\SignalRegistry;
+use SocialDept\AtpSignals\SignalServiceProvider;
+use SocialDept\AtpSignals\Storage\CursorStoreFactory;
+use SocialDept\AtpSignals\Storage\FileCursorStore;
+
+/**
+ * Regressions for how the v2 seq cursor is namespaced and resolved.
+ *
+ * Both cases are silent when wrong: the consumer keeps running and simply
+ * reads or writes the wrong position, so they are asserted rather than left
+ * to manual observation.
+ */
+class JetstreamV2CursorTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [SignalServiceProvider::class];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob(storage_path('signal/cursor*.json')) ?: [] as $file) {
+            @unlink($file);
+        }
+
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function the_firehose_keeps_its_own_cursor_while_jetstream_runs_v2()
+    {
+        config([
+            'atp-signals.cursor_storage' => 'file',
+            'atp-signals.jetstream_version' => 2,
+        ]);
+
+        $jetstream = $this->cursorPath($this->app->make(JetstreamConsumer::class));
+        $firehose = $this->cursorPath($this->app->make(FirehoseConsumer::class));
+
+        // Firehose seq numbers and Jetstream v2 seq numbers are different
+        // sequence spaces; sharing a slot silently corrupts the position.
+        $this->assertSame('cursor-jetstream-v2.json', $jetstream);
+        $this->assertSame('cursor.json', $firehose);
+    }
+
+    #[Test]
+    public function jetstream_v1_leaves_the_default_cursor_slot_alone()
+    {
+        config([
+            'atp-signals.cursor_storage' => 'file',
+            'atp-signals.jetstream_version' => 1,
+        ]);
+
+        $this->assertSame('cursor.json', $this->cursorPath($this->app->make(JetstreamConsumer::class)));
+        $this->assertSame('cursor.json', $this->cursorPath($this->app->make(FirehoseConsumer::class)));
+    }
+
+    #[Test]
+    public function a_reconnect_resolves_the_same_v1_seed_as_the_initial_start()
+    {
+        config([
+            'atp-signals.cursor_storage' => 'file',
+            'atp-signals.jetstream_version' => 2,
+        ]);
+
+        $seed = 1786830000000000;
+
+        // A real v1 position exists, and the v2 slot is still empty — the state
+        // every reconnect sees until the first event lands.
+        CursorStoreFactory::make()->set($seed);
+        $v2Store = CursorStoreFactory::make('jetstream-v2');
+        $v2Store->clear();
+
+        $consumer = new JetstreamConsumer($v2Store, new SignalRegistry(), Mockery::mock(EventDispatcher::class));
+
+        // start() and the reconnect timer both go through resolveCursor(), so a
+        // reconnect before the first event keeps the seeded position instead of
+        // silently restarting from live.
+        $this->assertSame($seed, $this->invokeMethod($consumer, 'resolveCursor', [null]));
+    }
+
+    #[Test]
+    public function an_explicit_zero_cursor_still_means_a_fresh_start()
+    {
+        config(['atp-signals.jetstream_version' => 2]);
+
+        $store = Mockery::mock(CursorStore::class);
+        $store->shouldNotReceive('get');
+
+        $consumer = new JetstreamConsumer($store, new SignalRegistry(), Mockery::mock(EventDispatcher::class));
+
+        $this->assertNull($this->invokeMethod($consumer, 'resolveCursor', [0]));
+    }
+
+    protected function cursorPath(object $consumer): string
+    {
+        $store = new \ReflectionProperty($consumer, 'cursorStore');
+        $store->setAccessible(true);
+        $store = $store->getValue($consumer);
+
+        $this->assertInstanceOf(FileCursorStore::class, $store);
+
+        $path = new \ReflectionProperty($store, 'path');
+        $path->setAccessible(true);
+
+        return basename($path->getValue($store));
+    }
+
+    protected function invokeMethod(&$object, $methodName, array $parameters = [])
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+}


### PR DESCRIPTION
## What

Two follow-up fixes to the Jetstream v2 support added in #13. Both are silent: the consumer keeps running and simply reads or writes the wrong position, so each is covered by a regression test.

## 1. A reconnect discarded the v1 → v2 cursor seed

A fresh v2 consumer seeds its position from the v1 `time_us` cursor — the mechanism that makes flipping `SIGNAL_JETSTREAM_VERSION=2` a gapless cutover. That seeding lived only in `start()`. `attemptReconnect()` read the still-empty v2 store directly, so any reconnect before the first event dropped the seed and restarted from live — permanently, since `start()` is never re-entered.

Observed against the live wire, seeding from a v1 position with a filtered subscription:

```
v1 cursor seeded at: 1786830000000000
CONNECT #1  cursor=1786830000000000
[Signal] No messages within idle timeout; reconnecting {"idle_timeout":5}
CONNECT #2  cursor=(NONE — starts live)
CONNECT #3  cursor=(NONE — starts live)
CONNECT #4  cursor=(NONE — starts live)
```

The idle watchdog added in the same PR makes this near-certain rather than rare on a **filtered, low-traffic** subscription: no matching events means the cursor never advances off `null`, so the watchdog reconnects every `idle_timeout` and every reconnect starts live again. The subscribers who most need gapless migration are the ones most likely to lose it, and nothing in the logs reports the discard — `start()` logs `Seeding v2 cursor from the v1 time_us position` once, which makes the migration look like it worked.

**Fix:** both paths now resolve through a single `resolveCursor()`, which also settles the cursor-of-`0` handling in one place instead of two (`start()` treated `0` as "fresh start", the reconnect path sent `cursor=0`).

## 2. The v2 cursor key was applied to the firehose consumer too

Scoping the v2 key by rebinding the shared `CursorStore::class` singleton also moved `FirehoseConsumer`'s cursor into the `jetstream-v2` slot whenever `SIGNAL_JETSTREAM_VERSION=2`, since both consumers resolve the same binding:

```
SIGNAL_JETSTREAM_VERSION=2, SIGNAL_MODE=firehose
   JetstreamConsumer cursor file: cursor-jetstream-v2.json
   FirehoseConsumer  cursor file: cursor-jetstream-v2.json   ← should be cursor.json
```

Firehose cursors are `com.atproto.sync.subscribeRepos` sequence numbers — a different sequence space from Jetstream v2 `seq`. Mixing them yields a wrong replay position with no error, which is the same hazard #13 set out to prevent, in the direction it didn't cover.

**Fix:** `JetstreamConsumer` takes its own explicitly-keyed store in its own binding, the way `ObeliskConsumer` already does. The default slot is left to the firehose.

## Testing

Four regressions in `tests/Unit/JetstreamV2CursorTest.php`, exercising the real file-backed stores and the real seeding path rather than mocks.

Verified they fail without the fix (source stashed, tests kept):

| Test | Without fix |
|------|-------------|
| `the_firehose_keeps_its_own_cursor_while_jetstream_runs_v2` | fails on assertion |
| `a_reconnect_resolves_the_same_v1_seed_as_the_initial_start` | errors — `resolveCursor()` absent |
| `an_explicit_zero_cursor_still_means_a_fresh_start` | errors — same |
| `jetstream_v1_leaves_the_default_cursor_slot_alone` | passes (control) |

With the fix: **75 tests, 201 assertions, green.** `php-cs-fixer` clean.

Also re-checked end to end against `jetstream.us-west.bsky.network` — v2 connect, all event kinds translating, seq cursor advancing — and confirmed v1 still builds the `/subscribe` URL with a `time_us` cursor and no `seq`.

## Notes

- Depends on #15 for a meaningful CI signal; until that lands, checks here fail at dependency install on the PHP 8.2 runner regardless of content.
- #14 tracks the related, pre-existing blocking `sleep()` and missing idle watchdog in `FirehoseConsumer`, which #13 fixed for Jetstream only.
