### PR TITLE
Run CI on PHP 8.4 and Laravel 13

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           extensions: gmp, mbstring, json
           coverage: none
           tools: php-cs-fixer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.3', '8.4']
 
-    name: Tests (PHP ${{ matrix.php }} - Laravel 12)
+    name: Tests (PHP 8.4 - Laravel 13)
 
     steps:
       - name: Checkout code
@@ -22,13 +18,13 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: 8.4
           extensions: gmp, mbstring, json
           coverage: none
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:^12.0" "orchestra/testbench:^10.0" --no-interaction --no-update
+          composer require "laravel/framework:^13.0" "orchestra/testbench:^11.0" --no-interaction --no-update
           composer update --prefer-stable --prefer-dist --no-interaction
 
       - name: Execute tests


### PR DESCRIPTION
## What

Brings this repo's CI in line with the rest of the family: a single job on the newest supported combination, rather than a PHP version behind.

## Change

- `tests.yml` and `code-style.yml` both run on **PHP 8.4**
- the install step pins **`laravel/framework:^13.0`** with **`orchestra/testbench:^11.0`**
- job label now reads *Tests (PHP 8.4 - Laravel 13)*

## Not changed

`composer.json` is untouched. Constraints stay as they are, so this is **not** a breaking release and nothing needs re-tagging — consumers on older Laravel and PHP 8.3 can still install.

CI verifies the newest supported combination rather than every declared one; older Laravel majors remain declared-but-untested by design.

## Verification

The suite was run locally against PHP 8.4 with Laravel 13 before this change; it passes.
