### PR TITLE
Drop the deleted dev branch from workflow triggers

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -2,7 +2,7 @@ name: Code Style
 
 on:
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
 
 jobs:
   php-cs-fixer:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
## What

The per-package `dev` branches have been deleted — they were a solo-maintainer staging area, replaced by the pull request workflow now enforced by the branch ruleset on `main`.

Both workflows still listed `dev` as a trigger target:

```yaml
on:
  pull_request:
    branches: [ main, dev ]
```

That half is now inert, since no `dev` branch exists to open a pull request against. This drops it so the trigger reflects reality:

```yaml
on:
  pull_request:
    branches: [ main ]
```

## Impact

None on behaviour. Pull requests into `main` trigger exactly as before; there is simply no longer a reference to a branch that does not exist.
