### PR TITLE
Pin php-cs-fixer to 3.95.18 in CI

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -18,7 +18,7 @@ jobs:
           php-version: 8.4
           extensions: gmp, mbstring, json
           coverage: none
-          tools: php-cs-fixer
+          tools: php-cs-fixer:3.95.18
 
       - name: Run PHP CS Fixer
         run: php-cs-fixer fix --dry-run --diff --verbose


### PR DESCRIPTION
## What

`code-style.yml` installed php-cs-fixer unpinned:

```yaml
tools: php-cs-fixer
```

`setup-php` resolves that to the latest release at run time, so an upstream version that adds
or tightens a rule can turn this check red with no change to the code. The style check was
effectively non-deterministic — a run could fail on a Tuesday for something that passed on a
Monday.

Pins it to the version currently in use:

```yaml
tools: php-cs-fixer:3.95.18
```

## Impact

None on behaviour. `3.95.18` is exactly what CI already resolved to, and what the fixer runs
as locally, so the same rules apply and the check stays green. The difference is that the
version now changes only when someone changes it.

Bumping later is a one-line edit, and doing it deliberately means any new formatting the
upgrade wants can land in the same pull request rather than appearing as an unexplained
failure on unrelated work.
